### PR TITLE
Inclusion of nsp to verify vulnerabilities before we publish the npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
   },
   "devDependencies": {
     "mocha": "^2.1.0",
-    "sinon": "^1.12.2"
+    "sinon": "^1.12.2",
+    "nsp": "*"
+  },
+  "scripts": {
+    "prepublish": "nsp audit-package"
   }
 }


### PR DESCRIPTION
This PR adds nsp (https://github.com/nodesecurity/nsp) responsible to check vulnerabilities against nodesecurity project.