### PR TITLE
RHMAP-11497 Handle subscribers: ADD, PATCH, DETACH

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ If you are using Node 7.x you can use the `--inspect --debug-brk` command line o
 
     $ npm run lint
 
+### Debugging
+
+#### Enable logging
+Logging can be enable by setting the `NODE_DEBUG` environment variable to the name of the JavaScript source file you want to enable logging for. For example:
+
+    $ env NODE_DEBUG=sync-engine node index.js
+
+Multiple JavaScript files can be added if you are interested in more than one by comma separating them.
+
 If you would like to help develop AeroGear you can join our [developer's mailing list](https://lists.jboss.org/mailman/listinfo/aerogear-dev), join #aerogear on Freenode, or shout at us on Twitter @aerogears.
 
 Also takes some time and skim the [contributor guide](http://aerogear.org/docs/guides/Contributing/)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ If you are using Node 7.x you can use the `--inspect --debug-brk` command line o
 > On previous version of Node, use [devtool](https://www.npmjs.com/package/devtool):
 > devtool test/sync-engine-test.js
 
+#### Enable debug logging
+Logging can be enable by setting the `NODE_DEBUG` environment variable to the name of the JavaScript source file you want to enable logging for. For example:
+
+    $ env NODE_DEBUG=sync-engine node index.js
+
 ### Running ESlint
 
     $ npm run lint
@@ -71,12 +76,6 @@ To automatically fix issues you can use:
 
     $ $ npm run lint -- --fix
 
-### Debugging
-
-#### Enable logging
-Logging can be enable by setting the `NODE_DEBUG` environment variable to the name of the JavaScript source file you want to enable logging for. For example:
-
-    $ env NODE_DEBUG=sync-engine node index.js
 
 Multiple JavaScript files can be added if you are interested in more than one by comma separating them.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ If you are using Node 7.x you can use the `--inspect --debug-brk` command line o
 
     $ npm run lint
 
+To automatically fix issues you can use:
+
+    $ $ npm run lint -- --fix
+
 ### Debugging
 
 #### Enable logging

--- a/lib/datastores/in-memory-store.js
+++ b/lib/datastores/in-memory-store.js
@@ -1,3 +1,5 @@
+const utils = require('../utils');
+
 /**
  * A server side {@link DataStore} implementation is responsible for storing
  * and serving data for a Differential Synchronization implementation.
@@ -32,7 +34,7 @@ var InMemoryDataStore = function () {
    */
   this.saveDocument = function (doc) {
     if (!docs[doc.id]) {
-      docs[doc.id] = doc;
+      docs[doc.id] = utils.poorMansCopy(doc);
       return true;
     }
     return false;
@@ -46,7 +48,7 @@ var InMemoryDataStore = function () {
   this.updateDocument = function (doc) {
     var existingDoc = this.getDocument(doc.id);
     if (existingDoc) {
-      docs[doc.id] = doc;
+      docs[doc.id] = utils.poorMansCopy(doc);
     }
   };
 
@@ -58,7 +60,7 @@ var InMemoryDataStore = function () {
       clientVersion: doc.clientVersion || 0,
       content: doc.content
     };
-    shadows[doc.id] = shadow;
+    shadows[doc.id] = utils.poorMansCopy(shadow);
 
     return shadow;
   };
@@ -83,7 +85,7 @@ var InMemoryDataStore = function () {
 
   this.saveShadowBackup = function (shadow, version) {
     var backup = {id: shadow.id, version: version, content: shadow.content};
-    backups[shadow.id] = backup;
+    backups[shadow.id] = utils.poorMansCopy(backup);
     return backup;
   };
 

--- a/lib/datastores/in-memory-store.js
+++ b/lib/datastores/in-memory-store.js
@@ -5,7 +5,10 @@
  * @constructor
  */
 var InMemoryDataStore = function () {
-  var stores = { docs: [], shadows: [], backups: [], edits: [] };
+  var docs = {};
+  var edits = {};
+  var shadows = {};
+  var backups = {};
 
   if (!(this instanceof InMemoryDataStore)) {
     return new InMemoryDataStore();
@@ -18,7 +21,7 @@ var InMemoryDataStore = function () {
    * @returns {Object} - the document
    */
   this.getDocument = function (docId) {
-    return this._readData(docId, 'docs');
+    return docs[docId];
   };
 
   /**
@@ -28,9 +31,8 @@ var InMemoryDataStore = function () {
    * @returns {Boolean} - true if the document was stored
    */
   this.saveDocument = function (doc) {
-    var existingDoc = this.getDocument(doc.id);
-    if (!existingDoc.length) {
-      this._saveData(doc, 'docs');
+    if (!docs[doc.id]) {
+      docs[doc.id] = doc;
       return true;
     }
     return false;
@@ -44,7 +46,7 @@ var InMemoryDataStore = function () {
   this.updateDocument = function (doc) {
     var existingDoc = this.getDocument(doc.id);
     if (existingDoc) {
-      this.saveDocument(doc);
+      docs[doc.id] = doc;
     }
   };
 
@@ -56,39 +58,61 @@ var InMemoryDataStore = function () {
       clientVersion: doc.clientVersion || 0,
       content: doc.content
     };
+    shadows[doc.id] = shadow;
 
-    this._saveData(shadow, 'shadows');
     return shadow;
   };
 
   this.getShadow = function (id) {
-    return this._readData(id, 'shadows')[0];
+    return shadows[id];
   };
 
   this.getBackup = function (id) {
-    return this._readData(id, 'backups')[0];
+    return backups[id];
+  };
+
+  this.getEdits = function (id, clientId) {
+    if (!edits[id]) {
+      return [];
+    }
+
+    return edits[id].filter(function (edit) {
+      return edit.id === id && edit.clientId === clientId;
+    });
   };
 
   this.saveShadowBackup = function (shadow, version) {
     var backup = {id: shadow.id, version: version, content: shadow.content};
-    this._saveData(backup, 'backups');
+    backups[shadow.id] = backup;
     return backup;
   };
 
-  this._saveData = function (doc, docType) {
-    doc = Array.isArray(doc) ? doc : [doc];
-    stores[docType] = doc;
+  /**
+   * Saves an Edit to the data store
+   *
+   * @param edit - the edit to store
+   */
+  this.saveEdit = function (edit) {
+    if (edits[edit.id]) {
+      edits[edit.id].push(edit);
+    } else {
+      edits[edit.id] = [edit];
+    }
   };
 
-  this._readData = function (id, type) {
-    return stores[type].filter(function (doc) {
-      return doc.id === id;
-    });
-  };
-
-  this.getEdits = function (id) {
-    var patchMessages = this._readData(id, 'edits');
-    return patchMessages.length ? patchMessages.edits : [];
+  /**
+   * Removes an edit
+   *
+   * @param edit - the edit to store
+   */
+  this.removeEdit = function (edit) {
+    if (edits[edit.id]) {
+      edits[edit.id].forEach(function (value, index, object) {
+        if (edit.clientId === value.clientId) {
+          object.splice(index, 1);
+        }
+      });
+    }
   };
 };
 

--- a/lib/datastores/in-memory-store.js
+++ b/lib/datastores/in-memory-store.js
@@ -1,7 +1,7 @@
 const utils = require('../utils');
 
 /**
- * A server side {@link DataStore} implementation is responsible for storing
+ * A server side DataStore implementation is responsible for storing
  * and serving data for a Differential Synchronization implementation.
  *
  * @constructor
@@ -17,10 +17,10 @@ var InMemoryDataStore = function () {
   }
 
   /**
-   * Retrieves the {@link Document} matching the passed-in document documentId.
+   * Retrieves the link Document matching the passed-in document documentId.
    *
    * @param documentId the document identifier of the shadow document.
-   * @returns {Object} - the document
+   * @returns Object - the document
    */
   this.getDocument = function (docId) {
     return docs[docId];
@@ -30,7 +30,7 @@ var InMemoryDataStore = function () {
    * Saves a server document.
    *
    * @param doc - the document to store
-   * @returns {Boolean} - true if the document was stored
+   * @returns Boolean - true if the document was stored
    */
   this.saveDocument = function (doc) {
     if (!docs[doc.id]) {
@@ -52,25 +52,125 @@ var InMemoryDataStore = function () {
     }
   };
 
-  this.saveShadow = function (doc) {
+  /**
+   * Removes the document from the store
+   *
+   * @param id - the document to remove
+   */
+  this.removeDocument = function (id) {
+    if (docs[id]) {
+      delete docs[id];
+    }
+  };
+
+  /**
+   * Saves a shadow of the document for the client.
+   *
+   * @param doc - the document to create a shadow of
+   * @param clientId - the client id for which the shadow belongs to
+   * @param serverVersion - the servers version that the shadow should be based on
+   * @param clientVersion - the client version that this shadow should match
+   * @return shadow - the saved shadow document
+   */
+  this.saveShadow = function (doc, clientId, serverVersion, clientVersion) {
+    var sversion = (typeof serverVersion !== 'undefined') ? serverVersion : 0;
+    var cversion = (typeof clientVersion !== 'undefined') ? clientVersion : 0;
     var shadow = {
       id: doc.id,
-      serverVersion: doc.serverVersion || 0,
-      clientId: doc.clientId,
-      clientVersion: doc.clientVersion || 0,
+      serverVersion: sversion,
+      clientId: clientId,
+      clientVersion: cversion,
       content: doc.content
     };
-    shadows[doc.id] = utils.poorMansCopy(shadow);
 
-    return shadow;
+    if (shadows[doc.id]) {
+      shadows[doc.id].push(shadow);
+    } else {
+      shadows[doc.id] = [shadow];
+    }
+    return utils.poorMansCopy(shadow);
   };
 
-  this.getShadow = function (id) {
-    return shadows[id];
+  /**
+   * Returns the shadow document for the document id and client id
+   * combination.
+   *
+   * @param id - the document id
+   * @param clientId - the client id
+   */
+  this.getShadow = function (id, clientId) {
+    if (!shadows[id]) {
+      return undefined;
+    }
+    const shadowForClient = shadows[id].filter(function (shadow) {
+      return shadow.clientId === clientId;
+    });
+    return shadowForClient[0];
   };
 
-  this.getBackup = function (id) {
-    return backups[id];
+  /**
+   * Remove the shadow document for the document id and client id
+   * combination.
+   *
+   * @param id - the document id
+   * @param clientId - the client id
+   */
+  this.removeShadow = function (id, clientId) {
+    if (shadows[id]) {
+      shadows[id].forEach(function (shadow, index, object) {
+        if (clientId === shadow.clientId) {
+          object.splice(index, 1);
+        }
+      });
+    }
+  };
+
+  /**
+   * Saves a backup of the clients shadow document
+   */
+  this.saveShadowBackup = function (shadow, version) {
+    var backup = { version: version, shadow: utils.poorMansCopy(shadow) };
+    if (backups[shadow.id]) {
+      backups[shadow.id].push(backup);
+    } else {
+      backups[shadow.id] = [backup];
+    }
+    return utils.poorMansCopy(backup);
+  };
+
+  /**
+   * Returns the shadow back up for id/client combination.
+   *
+   * @param id - the document id
+   * @param clientId - the client id
+   * @returns backup - the backup of the shadow document
+   */
+  this.getShadowBackup = function (id, clientId) {
+    if (!backups[id]) {
+      return undefined;
+    }
+
+    const backupForClient = backups[id].filter(function (backup) {
+      return backup.shadow.clientId === clientId;
+    });
+    return backupForClient[0];
+  };
+
+  /**
+   * Remove the shadow backup for the document id and client id
+   * combination.
+   *
+   * @param id - the document id
+   * @param clientId - the client id
+   */
+  this.removeShadowBackup = function (id, clientId) {
+    if (backups[id]) {
+      backups[id].forEach(function (backup, index, object) {
+        if (clientId === backup.shadow.clientId) {
+          object.splice(index, 1);
+        }
+      });
+    }
   };
 
   this.getEdits = function (id, clientId) {
@@ -81,12 +181,6 @@ var InMemoryDataStore = function () {
     return edits[id].filter(function (edit) {
       return edit.id === id && edit.clientId === clientId;
     });
-  };
-
-  this.saveShadowBackup = function (shadow, version) {
-    var backup = {id: shadow.id, version: version, content: shadow.content};
-    backups[shadow.id] = utils.poorMansCopy(backup);
-    return backup;
   };
 
   /**

--- a/lib/sync-engine.js
+++ b/lib/sync-engine.js
@@ -1,4 +1,6 @@
 'use strict';
+const util = require('util');
+const debuglog = util.debuglog('sync-engine');
 var utils = require('./utils');
 
 var SEEDED_CLIENT_VERSION = -1;
@@ -40,6 +42,7 @@ var SyncEngine = function (synchronizer, datastore) {
   };
 
   this.saveShadow = function (doc) {
+    debuglog('Save shadow:', doc);
     return datastore.saveShadow(doc);
   };
 
@@ -62,7 +65,7 @@ var SyncEngine = function (synchronizer, datastore) {
     patchMsg = {
       msgType: 'patch',
       id: doc.id,
-      clientId: doc.clientId,
+      clientId: shadow.clientId,
       edits: [synchronizer.serverDiff(doc, shadow)]
     };
 
@@ -75,11 +78,11 @@ var SyncEngine = function (synchronizer, datastore) {
     return patchMsg;
   };
 
-  this._seededShadowFrom = function (shadowDocument, doc) {
+  this._seededShadowFrom = function (shadow, doc) {
     var d = doc.content === null ? datastore.getDocument(doc.id) : doc;
     return {
       id: d.id,
-      clientId: shadowDocument.clientId,
+      clientId: shadow.clientId,
       serverVersion: SEEDED_SERVER_VERSION,
       clientVersion: SEEDED_CLIENT_VERSION,
       content: d.content
@@ -95,11 +98,6 @@ var SyncEngine = function (synchronizer, datastore) {
   };
 
   return this;
-};
-
-SyncEngine.prototype.addSubscriber = function (subscriber, document) {
-  console.log('TODO: ADD SUBSCRIBER STUFF');
-  return this.addDocument(document, subscriber.clientId);
 };
 
 SyncEngine.prototype.addDocument = function (document, clientId) {
@@ -129,6 +127,7 @@ SyncEngine.prototype.addDocument = function (document, clientId) {
 
   // Save document, and check if it was saved successfully
   saved = this.saveDocument(document);
+  debuglog('addedDocument: ', document);
   // Add Shadow for the client
   shadowDocument = this.addShadowForClient(document.id, clientId);
 
@@ -137,7 +136,7 @@ SyncEngine.prototype.addDocument = function (document, clientId) {
     shadowCopy.serverVersion++;
     patchMessage = this.serverDiff(shadowDocument, shadowCopy);
   } else {
-    console.log('Document with ID: ' + document.id + ' exists already');
+    debuglog('Document with ID: ' + document.id + ' exists already');
     seeded = this._seededShadowFrom(shadowDocument, document);
     patchMessage = this.serverDiff(shadowDocument, seeded);
   }
@@ -156,6 +155,7 @@ SyncEngine.prototype.addShadow = function (docId, clientId, clientVersion) {
   // Save Shadow
   shadowDocument = this.saveShadow(currentDocument);
   this.saveShadowBackup(currentDocument, 0);
+  debuglog('addedShadow: ', shadowDocument);
   return shadowDocument;
 };
 
@@ -173,10 +173,11 @@ SyncEngine.prototype.diff = function (docId, clientId) {
 };
 
 SyncEngine.prototype.patch = function (patchMessage) {
-  console.log('SyncEngine.patch patchMessage: ', patchMessage);
+  debuglog('SyncEngine.patch patchMessage: ', patchMessage);
   const docId = patchMessage.id;
   const clientId = patchMessage.clientId;
   var shadow = this.getShadow(docId);
+  debuglog('Shadow: ', shadow);
   const that = this;
 
   const edits = patchMessage.edits;
@@ -187,13 +188,14 @@ SyncEngine.prototype.patch = function (patchMessage) {
     }
     if (edit.clientVersion < shadow.clientVersion) {
       // already have this update so remove it
-      this.dataStore.removeEdit(edit, docId, clientId);
+      that.datastore.removeEdit(edit, docId, clientId);
       return;
     }
-    if (edit.serverVersion === shadow.serverVersion &&
-        edit.clientVersion === shadow.clientVersion) {
+    if ((edit.serverVersion === shadow.serverVersion &&
+        edit.clientVersion === shadow.clientVersion) ||
+        edit.clientVerssion === -1) {
       shadow = that.synchronizer.patchShadow(edit, shadow);
-      shadow.clientVersion += 1;
+      shadow.clientVersion = edit.clientVersion === -1 ? 0 : shadow.clientVersion++;
       that.datastore.removeEdit(edit);
       that.saveShadow(shadow);
     }
@@ -202,7 +204,7 @@ SyncEngine.prototype.patch = function (patchMessage) {
   var doc = this.getDocument(docId, 'docs');
   const edit = this.synchronizer.clientDiff(doc, shadow);
   const patchedDoc = this.synchronizer.patchDocument(edit, shadow);
-  console.log('Patched: ', patchedDoc);
+  debuglog('Patched: ', patchedDoc);
   this.datastore.updateDocument(patchedDoc);
   this.datastore.saveShadowBackup(shadow, shadow.serverVersion);
 };

--- a/lib/sync-engine.js
+++ b/lib/sync-engine.js
@@ -76,7 +76,7 @@ var SyncEngine = function (synchronizer, datastore) {
   };
 
   this._seededShadowFrom = function (shadowDocument, doc) {
-    var d = doc.content === null ? datastore.getDocument(doc.id)[0] : doc;
+    var d = doc.content === null ? datastore.getDocument(doc.id) : doc;
     return {
       id: d.id,
       clientId: shadowDocument.clientId,
@@ -108,7 +108,7 @@ SyncEngine.prototype.addDocument = function (document, clientId) {
   if (!document.content) {
     existingDoc = this.getDocument(document.id);
 
-    if (!existingDoc.length) {
+    if (!existingDoc) {
       patchMessage = {
         msgType: 'patch',
         id: document.id,
@@ -151,7 +151,7 @@ SyncEngine.prototype.addShadowForClient = function (docId, clientId) {
 
 SyncEngine.prototype.addShadow = function (docId, clientId, clientVersion) {
   var currentDocument, shadowDocument;
-  currentDocument = this.getDocument(docId, 'docs')[0];
+  currentDocument = this.getDocument(docId, 'docs');
   currentDocument.clientId = clientId;
   // Save Shadow
   shadowDocument = this.saveShadow(currentDocument);
@@ -167,13 +167,48 @@ SyncEngine.prototype.addShadow = function (docId, clientId, clientVersion) {
  * @param clientId the client id
  */
 SyncEngine.prototype.diff = function (docId, clientId) {
-  var doc = this.getDocument(docId, 'docs')[0];
+  var doc = this.getDocument(docId, 'docs');
   var shadow = this.getShadow(docId);
   return this.synchronizer.serverDiff(doc, shadow);
 };
 
 SyncEngine.prototype.patch = function (patchMessage) {
-  throw new Error('Patch Not Yet Implemeted');
+  console.log('SyncEngine.patch patchMessage: ', patchMessage);
+  const docId = patchMessage.id;
+  const clientId = patchMessage.clientId;
+  var shadow = this.getShadow(docId);
+  const that = this;
+
+  const edits = patchMessage.edits;
+  edits.forEach(function (edit) {
+    if (edit.serverVersion < shadow.serverVersion) {
+      shadow = restoreBackup(shadow, edit);
+      return;
+    }
+    if (edit.clientVersion < shadow.clientVersion) {
+      // already have this update so remove it
+      this.dataStore.removeEdit(edit, docId, clientId);
+      return;
+    }
+    if (edit.serverVersion === shadow.serverVersion &&
+        edit.clientVersion === shadow.clientVersion) {
+      shadow = that.synchronizer.patchShadow(edit, shadow);
+      shadow.clientVersion += 1;
+      that.datastore.removeEdit(edit);
+      that.saveShadow(shadow);
+    }
+  });
+
+  var doc = this.getDocument(docId, 'docs');
+  const edit = this.synchronizer.clientDiff(doc, shadow);
+  const patchedDoc = this.synchronizer.patchDocument(edit, shadow);
+  console.log('Patched: ', patchedDoc);
+  this.datastore.updateDocument(patchedDoc);
+  this.datastore.saveShadowBackup(shadow, shadow.serverVersion);
 };
+
+function restoreBackup (shadow, edit) {
+  // TODO implement this.
+}
 
 module.exports = SyncEngine;

--- a/lib/sync-engine.js
+++ b/lib/sync-engine.js
@@ -41,9 +41,9 @@ var SyncEngine = function (synchronizer, datastore) {
     return datastore.saveDocument(doc);
   };
 
-  this.saveShadow = function (doc) {
-    debuglog('Save shadow:', doc);
-    return datastore.saveShadow(doc);
+  this.saveShadow = function (doc, clientId) {
+    debuglog('Save shadow:', doc, 'for client', clientId);
+    return datastore.saveShadow(doc, clientId);
   };
 
   this.saveShadowBackup = function (shadow, version) {
@@ -150,10 +150,10 @@ SyncEngine.prototype.addShadowForClient = function (docId, clientId) {
 
 SyncEngine.prototype.addShadow = function (docId, clientId, clientVersion) {
   var currentDocument, shadowDocument;
-  currentDocument = this.getDocument(docId, 'docs');
+  currentDocument = this.getDocument(docId);
   currentDocument.clientId = clientId;
   // Save Shadow
-  shadowDocument = this.saveShadow(currentDocument);
+  shadowDocument = this.saveShadow(currentDocument, clientId);
   this.saveShadowBackup(currentDocument, 0);
   debuglog('addedShadow: ', shadowDocument);
   return shadowDocument;
@@ -167,7 +167,7 @@ SyncEngine.prototype.addShadow = function (docId, clientId, clientVersion) {
  * @param clientId the client id
  */
 SyncEngine.prototype.diff = function (docId, clientId) {
-  var doc = this.getDocument(docId, 'docs');
+  var doc = this.getDocument(docId);
   var shadow = this.getShadow(docId);
   return this.synchronizer.serverDiff(doc, shadow);
 };
@@ -193,15 +193,17 @@ SyncEngine.prototype.patch = function (patchMessage) {
     }
     if ((edit.serverVersion === shadow.serverVersion &&
         edit.clientVersion === shadow.clientVersion) ||
-        edit.clientVerssion === -1) {
+        edit.clientVersion === -1) {
       shadow = that.synchronizer.patchShadow(edit, shadow);
-      shadow.clientVersion = edit.clientVersion === -1 ? 0 : shadow.clientVersion++;
+      shadow.clientVersion += 1;
       that.datastore.removeEdit(edit);
-      that.saveShadow(shadow);
+      that.saveShadow(shadow, clientId);
     }
   });
 
-  var doc = this.getDocument(docId, 'docs');
+  var doc = this.getDocument(docId);
+  console.log('BEVE: doc', doc);
+  console.log('BEVE: shadow', shadow);
   const edit = this.synchronizer.clientDiff(doc, shadow);
   const patchedDoc = this.synchronizer.patchDocument(edit, shadow);
   debuglog('Patched: ', patchedDoc);

--- a/lib/sync-engine.js
+++ b/lib/sync-engine.js
@@ -79,7 +79,7 @@ var SyncEngine = function (synchronizer, datastore) {
   };
 
   this._seededShadowFrom = function (shadow, doc) {
-    var d = doc.content === null ? datastore.getDocument(doc.id) : doc;
+    var d = doc.content === undefined ? datastore.getDocument(doc.id) : doc;
     return {
       id: d.id,
       clientId: shadow.clientId,
@@ -105,7 +105,6 @@ SyncEngine.prototype.addDocument = function (document, clientId) {
 
   if (!document.content) {
     existingDoc = this.getDocument(document.id);
-
     if (!existingDoc) {
       patchMessage = {
         msgType: 'patch',
@@ -115,13 +114,11 @@ SyncEngine.prototype.addDocument = function (document, clientId) {
       };
     } else {
       shadowDocument = this.addShadowForClient(document.id, clientId);
-
       seeded = this._seededShadowFrom(shadowDocument, document);
       patchMessage = this.serverDiff(shadowDocument, seeded);
-
-      // TODO : updateDocument(patchDocument(shadow));
+      shadowDocument = this.synchronizer.patchShadow(patchMessage.edits[0], shadowDocument);
+      this.datastore.saveShadow(shadowDocument);
     }
-
     return patchMessage;
   }
 
@@ -202,8 +199,6 @@ SyncEngine.prototype.patch = function (patchMessage) {
   });
 
   var doc = this.getDocument(docId);
-  console.log('BEVE: doc', doc);
-  console.log('BEVE: shadow', shadow);
   const edit = this.synchronizer.clientDiff(doc, shadow);
   const patchedDoc = this.synchronizer.patchDocument(edit, shadow);
   debuglog('Patched: ', patchedDoc);

--- a/lib/sync-engine.js
+++ b/lib/sync-engine.js
@@ -89,12 +89,12 @@ var SyncEngine = function (synchronizer, datastore) {
     };
   };
 
-  this.getShadow = function (id) {
-    return datastore.getShadow(id);
+  this.getShadow = function (id, clientId) {
+    return datastore.getShadow(id, clientId);
   };
 
-  this.getBackup = function (id) {
-    return datastore.getBackup(id);
+  this.getShadowBackup = function (id, clientId) {
+    return datastore.getShadowBackup(id, clientId);
   };
 
   return this;
@@ -148,10 +148,9 @@ SyncEngine.prototype.addShadowForClient = function (docId, clientId) {
 SyncEngine.prototype.addShadow = function (docId, clientId, clientVersion) {
   var currentDocument, shadowDocument;
   currentDocument = this.getDocument(docId);
-  currentDocument.clientId = clientId;
   // Save Shadow
-  shadowDocument = this.saveShadow(currentDocument, clientId);
-  this.saveShadowBackup(currentDocument, 0);
+  shadowDocument = this.saveShadow(currentDocument, clientId, 0, clientVersion);
+  this.saveShadowBackup(shadowDocument, 0);
   debuglog('addedShadow: ', shadowDocument);
   return shadowDocument;
 };
@@ -165,7 +164,7 @@ SyncEngine.prototype.addShadow = function (docId, clientId, clientVersion) {
  */
 SyncEngine.prototype.diff = function (docId, clientId) {
   var doc = this.getDocument(docId);
-  var shadow = this.getShadow(docId);
+  var shadow = this.getShadow(docId, clientId);
   return this.synchronizer.serverDiff(doc, shadow);
 };
 
@@ -173,14 +172,14 @@ SyncEngine.prototype.patch = function (patchMessage) {
   debuglog('SyncEngine.patch patchMessage: ', patchMessage);
   const docId = patchMessage.id;
   const clientId = patchMessage.clientId;
-  var shadow = this.getShadow(docId);
-  debuglog('Shadow: ', shadow);
+  debuglog('docId: ', docId, clientId);
+  var shadow = this.getShadow(docId, clientId);
   const that = this;
 
   const edits = patchMessage.edits;
   edits.forEach(function (edit) {
     if (edit.serverVersion < shadow.serverVersion) {
-      shadow = restoreBackup(shadow, edit);
+      shadow = that.restoreBackup(shadow, edit);
       return;
     }
     if (edit.clientVersion < shadow.clientVersion) {
@@ -206,8 +205,20 @@ SyncEngine.prototype.patch = function (patchMessage) {
   this.datastore.saveShadowBackup(shadow, shadow.serverVersion);
 };
 
-function restoreBackup (shadow, edit) {
-  // TODO implement this.
-}
+SyncEngine.prototype.restoreBackup = function (shadow, edit) {
+  var backup = this.datastore.getShadowBackup(shadow.id, shadow.clientId);
+  if (backup.version === edit.serverVersion) {
+    console.log('backup: ', backup.shadow.content);
+    var patchedShadow = this.synchronizer.patchShadow(edit, backup.shadow);
+    patchedShadow.clientVersion += 1;
+    this.datastore.removeEdit(edit);
+    this.saveShadow(patchedShadow, patchedShadow.clientId);
+    return patchedShadow;
+  } else {
+    // Illegal state
+    debuglog('Restore backup:', backup);
+    throw new Error('Illegal state: restore backup');
+  }
+};
 
 module.exports = SyncEngine;

--- a/lib/sync-handler.js
+++ b/lib/sync-handler.js
@@ -8,7 +8,7 @@ var SyncHandler = function (syncEngine) {
     return new SyncHandler(syncEngine);
   }
   this.syncEngine = syncEngine;
-  this.subscribers = new Subscribers();
+  this.subscribers = new Subscribers(this);
   EventEmitter.call(this);
 };
 
@@ -17,7 +17,8 @@ util.inherits(SyncHandler, EventEmitter);
 // TODO: This is only going to be used as a initial
 // version for testing and the data structures will be updated
 // to more efficient ones.
-function Subscribers () {
+function Subscribers (emitter) {
+  this.emitter = emitter;
   this.forDocument = forDocument;
   this.addSubscriber = addSubscriber;
   this.removeSubscriber = removeSubscriber;
@@ -39,11 +40,13 @@ function addSubscriber (docId, clientId, client) {
 }
 
 function removeSubscriber (subscriber) {
+  const that = this;
   if (this.subscribers[subscriber.docId]) {
     this.subscribers[subscriber.docId].forEach(function (value, index, object) {
       if (subscriber.clientId === value.clientId) {
         console.log('delete subscriber: ', value.clientId);
         object.splice(index, 1);
+        that.emitter.emit('subscriberDeleted', value);
       }
     });
   }
@@ -74,11 +77,14 @@ SyncHandler.prototype.messageReceived = function (data, client) {
       this.emit('subscriberAdded', JSON.stringify(patchMessage), subscriber);
       break;
     case 'patch':
+      // TODO: implement this call but first add the code in SyncEngine
+      //  this.syncEngine.patch(json);
       var subs = this.subscribers.forDocument(docId);
       this.emit('patched', JSON.stringify({msg: 'patch not implemented yet'}), subs);
       break;
     case 'detach':
-      this.emit('detached', json);
+      this.subscribers.removeSubscriber(client.subscriber);
+      this.emit('detached', client.subscriber);
       break;
     default:
       const errorMsg = {

--- a/lib/sync-handler.js
+++ b/lib/sync-handler.js
@@ -8,38 +8,91 @@ var SyncHandler = function (syncEngine) {
     return new SyncHandler(syncEngine);
   }
   this.syncEngine = syncEngine;
+  this.subscribers = new Subscribers();
   EventEmitter.call(this);
 };
 
 util.inherits(SyncHandler, EventEmitter);
 
-SyncHandler.prototype.messageReceived = function (data, flags) {
-  var parsedData, patchMessage;
+// TODO: This is only going to be used as a initial
+// version for testing and the data structures will be updated
+// to more efficient ones.
+function Subscribers () {
+  this.forDocument = forDocument;
+  this.addSubscriber = addSubscriber;
+  this.removeSubscriber = removeSubscriber;
+  this.subscribers = {};
+}
 
+function forDocument (docId) {
+  return this.subscribers[docId];
+}
+
+function addSubscriber (docId, clientId, client) {
+  let subscriber = new Subscriber(docId, clientId, client);
+  if (this.subscribers[docId]) {
+    this.subscribers[docId].push(subscriber);
+  } else {
+    this.subscribers[docId] = new Array(subscriber);
+  }
+  return subscriber;
+}
+
+function removeSubscriber (subscriber) {
+  if (this.subscribers[subscriber.docId]) {
+    this.subscribers[subscriber.docId].forEach(function (value, index, object) {
+      if (subscriber.clientId === value.clientId) {
+        console.log('delete subscriber: ', value.clientId);
+        object.splice(index, 1);
+      }
+    });
+  }
+}
+
+function Subscriber (docId, clientId, client) {
+  this.docId = docId;
+  this.clientId = clientId;
+  this.client = client;
+}
+
+SyncHandler.prototype.messageReceived = function (data, client) {
+  var json;
   try {
-    parsedData = JSON.parse(data);
+    json = JSON.parse(data);
   } catch (e) {
     this.emit('error', e);
     return;
   }
 
-  switch (parsedData.msgType) {
-    case 'add':
-      // Something Something Subscribers?
+  const docId = json.id;
+  const clientId = json.clientId;
 
-      // Add the document
-      patchMessage = this.syncEngine.addDocument(parsedData, parsedData.clientId);
+  switch (json.msgType) {
+    case 'subscribe':
+      let patchMessage = this.syncEngine.addDocument(json, clientId);
+      let subscriber = this.subscribers.addSubscriber(docId, clientId, client);
+      this.emit('subscriberAdded', JSON.stringify(patchMessage), subscriber);
       break;
     case 'patch':
+      var subs = this.subscribers.forDocument(docId);
+      this.emit('patched', JSON.stringify({msg: 'patch not implemented yet'}), subs);
       break;
     case 'detach':
+      this.emit('detached', json);
       break;
     default:
-      patchMessage = 'Unknown msgType ' + parsedData.msgType;
-      break;
+      const errorMsg = {
+        id: json.id,
+        client: json.clientid,
+        msgType: 'error',
+        content: 'Unknown msgType: ' + json.msgType
+      };
+      this.emit('error', JSON.stringify(errorMsg), client);
   }
+};
 
-  this.emit('send', patchMessage);
+SyncHandler.prototype.clientClosed = function (subscriber) {
+  this.subscribers.removeSubscriber(subscriber);
 };
 
 module.exports = SyncHandler;

--- a/lib/sync-handler.js
+++ b/lib/sync-handler.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
 const util = require('util');
+const debuglog = util.debuglog('sync-handler');
+
+const EventEmitter = require('events').EventEmitter;
 
 var SyncHandler = function (syncEngine) {
   if (!(this instanceof SyncHandler)) {
@@ -25,26 +27,26 @@ function Subscribers (emitter) {
   this.subscribers = {};
 }
 
-function forDocument (docId) {
-  return this.subscribers[docId];
+function forDocument (id) {
+  return this.subscribers[id];
 }
 
-function addSubscriber (docId, clientId, client) {
-  let subscriber = new Subscriber(docId, clientId, client);
-  if (this.subscribers[docId]) {
-    this.subscribers[docId].push(subscriber);
+function addSubscriber (id, clientId, client) {
+  let subscriber = new Subscriber(id, clientId, client);
+  if (this.subscribers[id]) {
+    this.subscribers[id].push(subscriber);
   } else {
-    this.subscribers[docId] = new Array(subscriber);
+    this.subscribers[id] = new Array(subscriber);
   }
   return subscriber;
 }
 
 function removeSubscriber (subscriber) {
   const that = this;
-  if (this.subscribers[subscriber.docId]) {
-    this.subscribers[subscriber.docId].forEach(function (value, index, object) {
+  if (this.subscribers[subscriber.id]) {
+    this.subscribers[subscriber.id].forEach(function (value, index, object) {
       if (subscriber.clientId === value.clientId) {
-        console.log('delete subscriber: ', value.clientId);
+        debuglog('delete subscriber: ', value.clientId);
         object.splice(index, 1);
         that.emitter.emit('subscriberDeleted', value);
       }
@@ -52,8 +54,8 @@ function removeSubscriber (subscriber) {
   }
 }
 
-function Subscriber (docId, clientId, client) {
-  this.docId = docId;
+function Subscriber (id, clientId, client) {
+  this.id = id;
   this.clientId = clientId;
   this.client = client;
 }
@@ -67,20 +69,25 @@ SyncHandler.prototype.messageReceived = function (data, client) {
     return;
   }
 
-  const docId = json.id;
+  const id = json.id;
   const clientId = json.clientId;
 
   switch (json.msgType) {
     case 'subscribe':
       let patchMessage = this.syncEngine.addDocument(json, clientId);
-      let subscriber = this.subscribers.addSubscriber(docId, clientId, client);
+      let subscriber = this.subscribers.addSubscriber(id, clientId, client);
       this.emit('subscriberAdded', JSON.stringify(patchMessage), subscriber);
       break;
     case 'patch':
-      // TODO: implement this call but first add the code in SyncEngine
-      //  this.syncEngine.patch(json);
-      var subs = this.subscribers.forDocument(docId);
-      this.emit('patched', JSON.stringify({msg: 'patch not implemented yet'}), subs);
+      this.syncEngine.patch(json);
+      var subs = this.subscribers.forDocument(id);
+      const that = this;
+      subs.forEach(function (subscriber) {
+        const doc = that.syncEngine.getDocument(subscriber.id);
+        const shadow = that.syncEngine.getShadow(subscriber.id);
+        const patchMessage = that.syncEngine.serverDiff(doc, shadow);
+        that.emit('patched', JSON.stringify(patchMessage), subscriber);
+      });
       break;
     case 'detach':
       this.subscribers.removeSubscriber(client.subscriber);

--- a/lib/sync-handler.js
+++ b/lib/sync-handler.js
@@ -84,7 +84,7 @@ SyncHandler.prototype.messageReceived = function (data, client) {
       const that = this;
       subs.forEach(function (subscriber) {
         const doc = that.syncEngine.getDocument(subscriber.id);
-        const shadow = that.syncEngine.getShadow(subscriber.id);
+        const shadow = that.syncEngine.getShadow(subscriber.id, subscriber.clientId);
         const patchMessage = that.syncEngine.serverDiff(doc, shadow);
         that.emit('patched', JSON.stringify(patchMessage), subscriber);
       });

--- a/lib/synchronizers/diff-match-patch.js
+++ b/lib/synchronizers/diff-match-patch.js
@@ -117,8 +117,8 @@ function performDiff (doc, shadow, type) {
   }
 
   return {
-    serverVersion: shadow.clientVersion,
-    clientVersion: shadow.serverVersion,
+    serverVersion: shadow.serverVersion,
+    clientVersion: shadow.clientVersion,
     checksum: shadow.checksum,
     diffs: diffs.map(function (value) {
       return {

--- a/lib/synchronizers/diff-match-patch.js
+++ b/lib/synchronizers/diff-match-patch.js
@@ -21,7 +21,7 @@ var DiffMatchPatchSynchronizer = function (options) {
    * @return shadowDoc - the patched shadow document
    */
   this.patchShadow = function (edit, shadowDoc) {
-    shadowDoc.content = patch(edit, shadowDoc.content);
+    shadowDoc.content = patch(edit.diffs, shadowDoc.content);
     return shadowDoc;
   };
 

--- a/lib/synchronizers/diff-match-patch.js
+++ b/lib/synchronizers/diff-match-patch.js
@@ -102,7 +102,7 @@ function asAgOperation (op) {
 
 function performDiff (doc, shadow, type) {
   var diffs, docContent, shadowContent;
-  if (typeof docContent === 'string') {
+  if (typeof doc.content !== 'string') {
     docContent = JSON.stringify(doc.content);
     shadowContent = JSON.stringify(shadow.content);
   } else {

--- a/manual/ws.js
+++ b/manual/ws.js
@@ -1,0 +1,48 @@
+'use strict';
+
+//  const SyncEngine = require('../../lib/sync-engine.js');
+//  const InMemoryDataStore = require('../../lib/datastores/in-memory-store.js');
+//  const DiffMatchPatchSynchronizer = require('../../lib/synchronizers/diff-match-patch.js');
+const WebSocket = require('ws');
+const ws = new WebSocket('ws://localhost:7777/sync');
+
+//  const syncEngine = new SyncEngine(new DiffMatchPatchSynchronizer(),
+                                  //  new InMemoryDataStore());
+ws.on('open', function open () {
+  const payload = {
+    id: '1234',
+    clientId: '5678',
+    msgType: 'subscribe',
+    content: 1
+  };
+  ws.send(JSON.stringify(payload));
+});
+
+ws.on('message', function (data, flags) {
+  console.log(data);
+  var json;
+  try {
+    json = JSON.parse(data);
+  } catch (e) {
+    this.emit('error', e);
+    return;
+  }
+
+  switch (json.msgType) {
+    case 'patch':
+      console.log('Received patchMessage...', json);
+
+      let update = {
+        id: json.id,
+        clientId: json.clientId,
+        msgType: 'patch',
+        content: 2
+      };
+      console.log('send patch', JSON.stringify(update));
+      ws.send(JSON.stringify(update));
+      break;
+    case 'error':
+      console.log('Error', json.content);
+      break;
+  }
+});

--- a/manual/ws.js
+++ b/manual/ws.js
@@ -6,6 +6,8 @@ const SyncEngine = require('../lib/sync-engine.js');
 const WebSocket = require('ws');
 const ws = new WebSocket('ws://localhost:7777/sync');
 
+const clientId = '5678';
+
 const syncEngine = new SyncEngine(new DiffMatchPatchSynchronizer(),
                                   new InMemoryDataStore());
 ws.on('open', function open () {
@@ -16,7 +18,7 @@ ws.on('open', function open () {
   const subscribe = {
     msgType: 'subscribe',
     id: seedDoc.id,
-    clientId: '5678',
+    clientId: clientId,
     content: seedDoc.content
   }
   syncEngine.addDocument(seedDoc, subscribe.clientId);
@@ -39,7 +41,7 @@ ws.on('message', function (data, flags) {
       syncEngine.patch(json);
       const doc = syncEngine.getDocument(json.id);
       doc.content += 1;
-      const p = syncEngine.serverDiff(doc, syncEngine.getShadow(doc.id));
+      const p = syncEngine.serverDiff(doc, syncEngine.getShadow(doc.id, clientId));
       console.log(p);
        //ws.send(JSON.stringify(p));
       break;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --fix test/ index.js lib",
     "prepublish": "nsp check",
     "ci": "npm run lint && npm run coverage && npm run test && npm run prepublish",
-    "start": "node index.js",
+    "start": "env NODE_DEBUG=sync-ws-server node sync-ws-server.js",
     "docs": "./node_modules/.bin/jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./lib/*.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tape \"test/**/*.js\" | tap-spec",
     "coverage": "istanbul cover tape -- \"test/**/*.js\"",
     "lint": "eslint test/ index.js lib",
-    "lint:fix": "eslint --fix test/ index.js lib",
+    "lint:fix": "eslint --fix test/ sync-ws-server.js lib",
     "prepublish": "nsp check",
     "ci": "npm run lint && npm run coverage && npm run test && npm run prepublish",
     "start": "env NODE_DEBUG=sync-ws-server node sync-ws-server.js",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "test": "tape \"test/**/*.js\" | tap-spec",
     "coverage": "istanbul cover tape -- \"test/**/*.js\"",
-    "lint": "eslint test/ index.js lib",
-    "lint:fix": "eslint --fix test/ sync-ws-server.js lib",
+    "lint": "eslint test/ sync-ws-server.js lib/",
     "prepublish": "nsp check",
     "ci": "npm run lint && npm run coverage && npm run test && npm run prepublish",
     "start": "env NODE_DEBUG=sync-ws-server node sync-ws-server.js",

--- a/test/datastores/in-memory-store-test.js
+++ b/test/datastores/in-memory-store-test.js
@@ -3,6 +3,11 @@
 var test = require('tape');
 var InMemoryStore = require('../../lib/datastores/in-memory-store.js');
 
+test('[in-memory-store] create store without using new', function (t) {
+  t.ok(InMemoryStore(), 'instance was created even without using new');
+  t.end();
+});
+
 test('[in-memory-store] saveDocument', function (t) {
   var store = new InMemoryStore();
   const document = doc(1, 'It is a dark time for the Rebellion');
@@ -16,7 +21,7 @@ test('[in-memory-store] getDocument', function (t) {
   const document = doc(1, 'It is a dark time for the Rebellion');
   store.saveDocument(document);
 
-  const readDoc = store.getDocument(document.id)[0];
+  const readDoc = store.getDocument(document.id);
   t.equals(readDoc.id, document.id);
   t.equals(readDoc.content, document.content);
 
@@ -31,10 +36,62 @@ test('[in-memory-store] updateDocument', function (t) {
   document.content = document.content + '.';
   store.updateDocument(document);
 
-  const readDoc = store.getDocument(document.id)[0];
+  const readDoc = store.getDocument(document.id);
   t.equals(readDoc.id, document.id);
   t.equals(readDoc.content, document.content);
 
+  t.end();
+});
+
+test('[in-memory-store] saveEdit', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const edit = {
+    id: docId,
+    clientId: clientId,
+    diffs: []
+  };
+  store.saveEdit(edit);
+  const edits = store.getEdits(docId, clientId);
+  t.equals(edits[0].id, docId);
+  t.equals(edits[0].clientId, clientId);
+  t.end();
+});
+
+test('[in-memory-store] saveEdit existing edits', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const edit1 = {
+    id: docId,
+    clientId: clientId,
+    diffs: []
+  };
+  const edit2 = {
+    id: docId,
+    clientId: clientId,
+    diffs: []
+  };
+  store.saveEdit(edit1);
+  store.saveEdit(edit2);
+  const edits = store.getEdits(docId, clientId);
+  t.equals(edits.length, 2);
+  t.end();
+});
+
+test('[in-memory-store] removeEdit', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const edit = {
+    id: docId,
+    clientId: clientId,
+    diffs: []
+  };
+  store.saveEdit(edit);
+  const edits = store.getEdits(docId, clientId);
+  store.removeEdit(edits[0]);
   t.end();
 });
 

--- a/test/datastores/in-memory-store-test.js
+++ b/test/datastores/in-memory-store-test.js
@@ -10,7 +10,7 @@ test('[in-memory-store] create store without using new', function (t) {
 
 test('[in-memory-store] saveDocument', function (t) {
   var store = new InMemoryStore();
-  const document = doc(1, 'It is a dark time for the Rebellion');
+  const document = { id: 1, content: 'It is a dark time for the Rebellion' };
   t.ok(store.saveDocument(document), 'Document was saved');
 
   t.end();
@@ -18,19 +18,19 @@ test('[in-memory-store] saveDocument', function (t) {
 
 test('[in-memory-store] getDocument', function (t) {
   var store = new InMemoryStore();
-  const document = doc(1, 'It is a dark time for the Rebellion');
+  const document = { id: 1, content: 'It is a dark time for the Rebellion' };
   store.saveDocument(document);
-
   const readDoc = store.getDocument(document.id);
   t.equals(readDoc.id, document.id);
   t.equals(readDoc.content, document.content);
+  t.notOk(readDoc.clientId, 'document should not have a client id');
 
   t.end();
 });
 
 test('[in-memory-store] updateDocument', function (t) {
   var store = new InMemoryStore();
-  var document = doc(1, 'It is a dark time for the Rebellion');
+  const document = { id: 1, content: 'It is a dark time for the Rebellion' };
   store.saveDocument(document);
 
   document.content = document.content + '.';
@@ -39,6 +39,18 @@ test('[in-memory-store] updateDocument', function (t) {
   const readDoc = store.getDocument(document.id);
   t.equals(readDoc.id, document.id);
   t.equals(readDoc.content, document.content);
+  t.notOk(readDoc.clientId, 'document should not have a client id');
+
+  t.end();
+});
+
+test('[in-memory-store] removeDocument', function (t) {
+  var store = new InMemoryStore();
+  const document = { id: 1, content: 'It is a dark time for the Rebellion' };
+  store.saveDocument(document);
+  t.ok(store.getDocument(document.id));
+  store.removeDocument(document.id);
+  t.notOk(store.getDocument(document.id));
 
   t.end();
 });
@@ -95,12 +107,92 @@ test('[in-memory-store] removeEdit', function (t) {
   t.end();
 });
 
-function doc (id, content, clientId, serverVersion, clientVersion) {
-  return {
-    id: id,
-    clientId: clientId || 'dummyId',
-    serverVersion: serverVersion || 'serverVersion',
-    clientVersion: clientVersion || 'clientVersion',
-    content: content
-  };
-}
+test('[in-memory-store] saveShadow', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const document = { id: docId, content: 'It is a dark time for the Rebellion' };
+  store.saveDocument(document);
+  store.saveShadow(document, clientId);
+
+  const shadow = store.getShadow(docId, clientId);
+  console.log(shadow.serverVersion);
+  t.equals(shadow.id, docId);
+  t.equals(shadow.clientId, clientId);
+  t.equals(shadow.clientVersion, 0, 'shadow must have a clientVersion');
+  t.equals(shadow.serverVersion, 0, 'shadow must have a serverVersion');
+  t.end();
+});
+
+test('[in-memory-store] getShadow none saved', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const document = { id: docId, content: 'It is a dark time for the Rebellion' };
+  store.saveDocument(document);
+
+  const shadow = store.getShadow(docId, clientId);
+  t.notOk(shadow);
+  t.end();
+});
+
+test('[in-memory-store] removeShadow', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const document = { id: docId, content: 'It is a dark time for the Rebellion' };
+  store.saveDocument(document);
+  store.saveShadow(document, clientId);
+  t.ok(store.getShadow(docId, clientId));
+  store.removeShadow(docId, clientId);
+  t.notOk(store.getShadow(docId, clientId));
+  t.end();
+});
+
+test('[in-memory-store] saveShadowBackup', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const document = { id: docId, content: 'It is a dark time for the Rebellion' };
+  store.saveDocument(document);
+  const shadow = store.saveShadow(document, clientId);
+  const backup = store.saveShadowBackup(shadow, 1);
+  t.equals(backup.version, 1, 'backup must have a version');
+  t.equals(backup.shadow.id, docId);
+  t.equals(backup.shadow.clientId, clientId);
+  t.equals(backup.shadow.serverVersion, 0, 'shadow must have a serverVersion');
+  t.equals(backup.shadow.clientVersion, 0, 'shadow must have a clientVersion');
+  t.end();
+});
+
+test('[in-memory-store] getShadowBackup', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const document = { id: docId, content: 'It is a dark time for the Rebellion' };
+  store.saveDocument(document);
+  const shadow = store.saveShadow(document, clientId);
+  store.saveShadowBackup(shadow, 1);
+  const backup = store.getShadowBackup(docId, clientId);
+  t.equals(backup.version, 1, 'backup must have a version');
+  t.equals(backup.shadow.id, docId);
+  t.equals(backup.shadow.clientId, clientId);
+  t.equals(backup.shadow.serverVersion, 0, 'shadow must have a serverVersion');
+  t.equals(backup.shadow.clientVersion, 0, 'shadow must have a clientVersion');
+  t.end();
+});
+
+test('[in-memory-store] removeShadowBackup', function (t) {
+  const store = new InMemoryStore();
+  const docId = '1234';
+  const clientId = '5678';
+  const document = { id: docId, content: 'It is a dark time for the Rebellion' };
+  store.saveDocument(document);
+  const shadow = store.saveShadow(document, clientId);
+  store.saveShadowBackup(shadow, clientId);
+  t.ok(store.getShadowBackup(docId, clientId));
+  store.removeShadowBackup(docId, clientId);
+  t.notOk(store.getShadowBackup(docId, clientId));
+  t.end();
+});
+

--- a/test/sync-engine-test.js
+++ b/test/sync-engine-test.js
@@ -108,3 +108,32 @@ test('[server-sync-engine] diff', function (t) {
   t.equal(edit.diffs[0].operation, 'UNCHANGED');
   t.end();
 });
+
+test('[server-sync-engine] patch', function (t) {
+  const synchronizer = new DiffMatchPatchSynchronizer();
+  const syncEngine = new SyncEngine(synchronizer, new InMemoryDataStore());
+  const clientId = uuid.v4();
+  const doc = {
+    id: '1234',
+    content: 'stop calling me shirley'
+  };
+  syncEngine.addDocument(doc, clientId);
+  const shadow = {
+    id: doc.id,
+    clientId: doc.clientId,
+    clientVersion: 0,
+    serverVersion: 0,
+    content: 'stop calling me Shirley'
+  };
+  const edit = synchronizer.clientDiff(doc, shadow);
+  const patchMessage = {
+    msgType: 'patch',
+    id: doc.id,
+    clientId: doc.clientId,
+    edits: [edit]
+  };
+  syncEngine.patch(patchMessage);
+  const patched = syncEngine.getDocument(doc.id);
+  t.equal(patched.content, 'stop calling me Shirley');
+  t.end();
+});

--- a/test/sync-engine-test.js
+++ b/test/sync-engine-test.js
@@ -46,6 +46,54 @@ test('[server-sync-engine] addDocument', function (t) {
   t.end();
 });
 
+test('[server-sync-engine] addDocument multiple times verify seeded', function (t) {
+  const syncEngine = new SyncEngine(new DiffMatchPatchSynchronizer(),
+                                    new InMemoryDataStore());
+  const clientId = uuid.v4();
+  const doc = {
+    id: '1234',
+    content: 'A long time ago in a galaxy far, far away....'
+  };
+  syncEngine.addDocument(doc, clientId);
+  const patchMessage = syncEngine.addDocument(doc, 'client2');
+  t.equal(patchMessage.edits.length, 1, 'should be one edit');
+  t.equal(patchMessage.edits[0].clientVersion, -1, 'client version should be -1');
+  t.equal(patchMessage.edits[0].serverVersion, 1, 'server version should be 1');
+  t.equal(patchMessage.edits[0].diffs[0].operation, 'UNCHANGED', 'should be an \'UNCHANGED\' operation');
+  t.equal(patchMessage.edits[0].diffs[0].text, doc.content, 'content should be unchanged');
+  t.equal(patchMessage.clientId, 'client2', 'client id should match');
+
+  t.end();
+});
+
+/**
+ * Calling addDocument with the document id of an already existing document, allows
+ * for clients to "attach" to a current document without having to provide an empty
+ * document content when using subscribe.
+ */
+test('[server-sync-engine] addDocument twice second time without content', function (t) {
+  const syncEngine = new SyncEngine(new DiffMatchPatchSynchronizer(),
+                                    new InMemoryDataStore());
+  const clientId = uuid.v4();
+  const doc = {
+    id: '1234',
+    content: 'A long time ago in a galaxy far, far away....'
+  };
+  syncEngine.addDocument(doc, clientId);
+  const noContent = {
+    id: '1234'
+  };
+  const patchMessage = syncEngine.addDocument(noContent, 'client2');
+  t.equal(patchMessage.edits.length, 1, 'should be one edit');
+  t.equal(patchMessage.edits[0].clientVersion, -1, 'client version should be -1');
+  t.equal(patchMessage.edits[0].serverVersion, 1, 'server version should be 1');
+  t.equal(patchMessage.edits[0].diffs[0].operation, 'UNCHANGED', 'should be an \'UNCHANGED\' operation');
+  t.equal(patchMessage.edits[0].diffs[0].text, doc.content, 'content should be unchanged');
+  t.equal(patchMessage.clientId, 'client2', 'client id should match');
+
+  t.end();
+});
+
 test('[server-sync-engine] addDocument empty content but document already exists', function (t) {
   const synchronizer = new DiffMatchPatchSynchronizer();
   const syncEngine = new SyncEngine(synchronizer, new InMemoryDataStore());

--- a/test/sync-engine-test.js
+++ b/test/sync-engine-test.js
@@ -80,7 +80,7 @@ test('[server-sync-engine] verify shadow', function (t) {
   syncEngine.addDocument(doc, clientId);
   const shadow = syncEngine.getShadow(doc.id, clientId);
   t.equal(shadow.id, doc.id, 'id\'s should be the same');
-  t.equal(shadow.clientId, doc.clientId, 'clientId\'s should be the same');
+  t.equal(shadow.clientId, shadow.clientId, 'clientId\'s should be the same');
   t.equal(shadow.serverVersion, 0, 'server version should be 0');
   t.equal(shadow.clientVersion, 0, 'client version should be 0');
   t.equal(shadow.content, doc.content, 'content should be the same');

--- a/test/sync-engine-test.js
+++ b/test/sync-engine-test.js
@@ -196,7 +196,8 @@ test('[server-sync-engine] patch', function (t) {
 
 test('[server-sync-engine] patch but server already has the client version', function (t) {
   const synchronizer = new DiffMatchPatchSynchronizer();
-  const syncEngine = new SyncEngine(synchronizer, new InMemoryDataStore());
+  const datastore = new InMemoryDataStore();
+  const syncEngine = new SyncEngine(synchronizer, datastore);
   const clientId = uuid.v4();
   const doc = {
     id: '1234',
@@ -218,7 +219,10 @@ test('[server-sync-engine] patch but server already has the client version', fun
     edits: [edit]
   };
   syncEngine.patch(patchMessage);
+  // call again with the same patch message
+  syncEngine.patch(patchMessage);
   const patched = syncEngine.getDocument(doc.id);
   t.equal(patched.content, 'stop calling me Shirley');
+  t.equal(datastore.getEdits(doc.id, clientId).length, 0);
   t.end();
 });

--- a/test/sync-engine-test.js
+++ b/test/sync-engine-test.js
@@ -16,7 +16,7 @@ test('[server-sync-engine] create new SyncEngine', function (t) {
 
 test('[server-sync-engine] addDocument empty content', function (t) {
   const syncEngine = new SyncEngine(new DiffMatchPatchSynchronizer(),
-                                              new InMemoryDataStore());
+                                    new InMemoryDataStore());
   const clientId = uuid.v4();
   const doc = {
     id: '1234'
@@ -30,7 +30,7 @@ test('[server-sync-engine] addDocument empty content', function (t) {
 
 test('[server-sync-engine] addDocument', function (t) {
   const syncEngine = new SyncEngine(new DiffMatchPatchSynchronizer(),
-                                        new InMemoryDataStore());
+                                    new InMemoryDataStore());
   const clientId = uuid.v4();
   const doc = {
     id: '1234',

--- a/test/sync-handler-test.js
+++ b/test/sync-handler-test.js
@@ -53,8 +53,8 @@ test('[sync-handler] messageRecieved: msgType subscribe', function (t) {
     t.equal(json.id, payload.id, 'id\'s should match');
     t.equal(json.clientId, payload.clientId, 'clientId\'s should match');
     t.equal(json.edits.length, 1, 'should be one edit');
-    t.equal(json.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
-    t.equal(json.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
+    t.equal(json.edits[0].serverVersion, 1, 'edit serverVersion should be 0');
+    t.equal(json.edits[0].clientVersion, 0, 'edit clientVersion should be 1');
     t.equal(json.edits[0].checksum, undefined, 'TODO: implement checksum');
     t.equal(json.edits[0].diffs.length, 1, 'edit should contain one diff');
     t.equal(json.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
@@ -79,8 +79,8 @@ test('[sync-handler] messageRecieved: msgType subscribe object content', functio
     t.equal(json.id, payload.id, 'id\'s should match');
     t.equal(json.clientId, payload.clientId, 'clientId\'s should match');
     t.equal(json.edits.length, 1, 'should be one edit');
-    t.equal(json.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
-    t.equal(json.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
+    t.equal(json.edits[0].serverVersion, 1, 'edit serverVersion should be 0');
+    t.equal(json.edits[0].clientVersion, 0, 'edit clientVersion should be 1');
     t.equal(json.edits[0].checksum, undefined, 'TODO: implement checksum');
     t.equal(json.edits[0].diffs.length, 1, 'edit should contain one diff');
     t.equal(json.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
@@ -103,8 +103,8 @@ test('[sync-handler] messageRecieved: msgType subscribe array content', function
     t.equal(json.id, payload.id, 'id\'s should match');
     t.equal(json.clientId, payload.clientId, 'clientId\'s should match');
     t.equal(json.edits.length, 1, 'should be one edit');
-    t.equal(json.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
-    t.equal(json.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
+    t.equal(json.edits[0].serverVersion, 1, 'edit serverVersion should be 0');
+    t.equal(json.edits[0].clientVersion, 0, 'edit clientVersion should be 1');
     t.equal(json.edits[0].checksum, undefined, 'TODO: implement checksum');
     t.equal(json.edits[0].diffs.length, 1, 'edit should contain one diff');
     t.equal(json.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
@@ -122,7 +122,7 @@ test('[sync-handler] clientClosed', function (t) {
   };
   const handler = new SyncHandler(createSyncEngine());
   handler.on('subscriberDeleted', function (subscriber) {
-    t.equal(subscriber.docId, payload.id, 'document id should match');
+    t.equal(subscriber.id, payload.id, 'document id should match');
     t.equal(subscriber.clientId, payload.clientId, 'client id should match');
     t.ok(subscriber.client, 'client should exist');
     t.end();
@@ -130,7 +130,7 @@ test('[sync-handler] clientClosed', function (t) {
   handler.on('subscriberAdded', function (patchMessage) {
     const json = JSON.parse(patchMessage);
     const subscriber = {
-      docId: json.id,
+      id: json.id,
       clientId: json.clientId,
       client: {}
     };
@@ -148,7 +148,7 @@ test('[sync-handler] detach', function (t) {
   };
   const handler = new SyncHandler(createSyncEngine());
   handler.on('detached', function (subscriber) {
-    t.equal(subscriber.docId, payload.id, 'document id should match');
+    t.equal(subscriber.id, payload.id, 'document id should match');
     t.equal(subscriber.clientId, payload.clientId, 'client id should match');
     t.ok(subscriber.client, 'client should exist');
     t.end();
@@ -156,12 +156,12 @@ test('[sync-handler] detach', function (t) {
   handler.on('subscriberAdded', function (patchMessage) {
     const json = JSON.parse(patchMessage);
     const detach = {
-      docId: json.id,
+      id: json.id,
       clientId: json.clientId,
       msgType: 'detach'
     };
     const subscriber = {
-      docId: json.id,
+      id: json.id,
       clientId: json.clientId,
       client: {}
     };
@@ -201,6 +201,10 @@ test('[sync-handler] patch', function (t) {
     handler.messageReceived(JSON.stringify(patch), {});
 
     t.end();
+  });
+  handler.on('patched', function (patchMessage, subscriber) {
+    t.equal(subscriber.id, payload.id, 'document id should match');
+    t.equal(subscriber.clientId, payload.clientId, 'client id should match');
   });
   handler.messageReceived(JSON.stringify(payload), {});
 });

--- a/test/sync-handler-test.js
+++ b/test/sync-handler-test.js
@@ -183,7 +183,7 @@ test('[sync-handler] patch', function (t) {
   const syncEngine = new SyncEngine(synchronizer, dataStore);
   const handler = new SyncHandler(syncEngine);
   handler.on('subscriberAdded', function (patchMessage) {
-    var doc = dataStore.getDocument(payload.id)[0];
+    var doc = dataStore.getDocument(payload.id);
     const shadow = {
       id: doc.id,
       clientId: doc.clientId,
@@ -199,6 +199,7 @@ test('[sync-handler] patch', function (t) {
       edits: [edit]
     };
     handler.messageReceived(JSON.stringify(patch), {});
+
     t.end();
   });
   handler.messageReceived(JSON.stringify(payload), {});

--- a/test/sync-handler-test.js
+++ b/test/sync-handler-test.js
@@ -23,72 +23,75 @@ test('[sync-handler] messageReceived: undefined', function (t) {
   handler.messageReceived();
 });
 
-test('[sync-handler] messageRecieved: msgType add', function (t) {
+test('[sync-handler] messageRecieved: msgType subscribe', function (t) {
   const payload = {
     id: uuid.v4(),
     clientId: uuid.v4(),
-    msgType: 'add',
+    msgType: 'subscribe',
     content: 'stop calling me Shirley'
   };
   const handler = new SyncHandler(createSyncEngine());
-  handler.on('send', function (patchMessage) {
-    t.equal(patchMessage.msgType, 'patch', 'msgType should be patch');
-    t.equal(patchMessage.id, payload.id, 'id\'s should match');
-    t.equal(patchMessage.clientId, payload.clientId, 'clientId\'s should match');
-    t.equal(patchMessage.edits.length, 1, 'should be one edit');
-    t.equal(patchMessage.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
-    t.equal(patchMessage.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
-    t.equal(patchMessage.edits[0].checksum, undefined, 'TODO: implement checksum');
-    t.equal(patchMessage.edits[0].diffs.length, 1, 'edit should contain one diff');
-    t.equal(patchMessage.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
+  handler.on('subscriberAdded', function (patchMessage) {
+    const json = JSON.parse(patchMessage);
+    t.equal(json.msgType, 'patch', 'msgType should be patch');
+    t.equal(json.id, payload.id, 'id\'s should match');
+    t.equal(json.clientId, payload.clientId, 'clientId\'s should match');
+    t.equal(json.edits.length, 1, 'should be one edit');
+    t.equal(json.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
+    t.equal(json.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
+    t.equal(json.edits[0].checksum, undefined, 'TODO: implement checksum');
+    t.equal(json.edits[0].diffs.length, 1, 'edit should contain one diff');
+    t.equal(json.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
     t.end();
   });
   handler.messageReceived(JSON.stringify(payload));
 });
 
-test('[sync-handler] messageRecieved: msgType add object content', function (t) {
+test('[sync-handler] messageRecieved: msgType subscribe object content', function (t) {
   const payload = {
     id: uuid.v4(),
     clientId: uuid.v4(),
-    msgType: 'add',
+    msgType: 'subscribe',
     content: {
       name: 'Dr. Rosen'
     }
   };
   const handler = new SyncHandler(createSyncEngine());
-  handler.on('send', function (patchMessage) {
-    t.equal(patchMessage.msgType, 'patch', 'msgType should be patch');
-    t.equal(patchMessage.id, payload.id, 'id\'s should match');
-    t.equal(patchMessage.clientId, payload.clientId, 'clientId\'s should match');
-    t.equal(patchMessage.edits.length, 1, 'should be one edit');
-    t.equal(patchMessage.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
-    t.equal(patchMessage.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
-    t.equal(patchMessage.edits[0].checksum, undefined, 'TODO: implement checksum');
-    t.equal(patchMessage.edits[0].diffs.length, 1, 'edit should contain one diff');
-    t.equal(patchMessage.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
+  handler.on('subscriberAdded', function (patchMessage) {
+    const json = JSON.parse(patchMessage);
+    t.equal(json.msgType, 'patch', 'msgType should be patch');
+    t.equal(json.id, payload.id, 'id\'s should match');
+    t.equal(json.clientId, payload.clientId, 'clientId\'s should match');
+    t.equal(json.edits.length, 1, 'should be one edit');
+    t.equal(json.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
+    t.equal(json.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
+    t.equal(json.edits[0].checksum, undefined, 'TODO: implement checksum');
+    t.equal(json.edits[0].diffs.length, 1, 'edit should contain one diff');
+    t.equal(json.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
     t.end();
   });
   handler.messageReceived(JSON.stringify(payload));
 });
 
-test('[sync-handler] messageRecieved: msgType add array content', function (t) {
+test('[sync-handler] messageRecieved: msgType subscribe array content', function (t) {
   const payload = {
     id: uuid.v4(),
     clientId: uuid.v4(),
-    msgType: 'add',
+    msgType: 'subscribe',
     content: ['one', 'two', 'three']
   };
   const handler = new SyncHandler(createSyncEngine());
-  handler.on('send', function (patchMessage) {
-    t.equal(patchMessage.msgType, 'patch', 'msgType should be patch');
-    t.equal(patchMessage.id, payload.id, 'id\'s should match');
-    t.equal(patchMessage.clientId, payload.clientId, 'clientId\'s should match');
-    t.equal(patchMessage.edits.length, 1, 'should be one edit');
-    t.equal(patchMessage.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
-    t.equal(patchMessage.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
-    t.equal(patchMessage.edits[0].checksum, undefined, 'TODO: implement checksum');
-    t.equal(patchMessage.edits[0].diffs.length, 1, 'edit should contain one diff');
-    t.equal(patchMessage.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
+  handler.on('subscriberAdded', function (patchMessage) {
+    const json = JSON.parse(patchMessage);
+    t.equal(json.msgType, 'patch', 'msgType should be patch');
+    t.equal(json.id, payload.id, 'id\'s should match');
+    t.equal(json.clientId, payload.clientId, 'clientId\'s should match');
+    t.equal(json.edits.length, 1, 'should be one edit');
+    t.equal(json.edits[0].serverVersion, 0, 'edit serverVersion should be 0');
+    t.equal(json.edits[0].clientVersion, 1, 'edit clientVersion should be 1');
+    t.equal(json.edits[0].checksum, undefined, 'TODO: implement checksum');
+    t.equal(json.edits[0].diffs.length, 1, 'edit should contain one diff');
+    t.equal(json.edits[0].diffs[0].operation, 'UNCHANGED', 'operation should be UNCHANGED');
     t.end();
   });
   handler.messageReceived(JSON.stringify(payload));

--- a/test/synchronizers/diff-match-patch-synchronizer-test.js
+++ b/test/synchronizers/diff-match-patch-synchronizer-test.js
@@ -94,7 +94,7 @@ test('[diff-match-patch synchronizer] patchShadow', function (t) {
   };
 
   const edit = synchronizer.clientDiff(doc, updatedDoc);
-  patchedShadow = synchronizer.patchShadow(edit.diffs, shadow);
+  patchedShadow = synchronizer.patchShadow(edit, shadow);
   t.equal(patchedShadow.content, 'Cool Dude', 'shadow test should be Cool Dude');
 
   t.end();

--- a/test/synchronizers/diff-match-patch-synchronizer-test.js
+++ b/test/synchronizers/diff-match-patch-synchronizer-test.js
@@ -96,6 +96,8 @@ test('[diff-match-patch synchronizer] patchShadow', function (t) {
   const edit = synchronizer.clientDiff(doc, updatedDoc);
   patchedShadow = synchronizer.patchShadow(edit, shadow);
   t.equal(patchedShadow.content, 'Cool Dude', 'shadow test should be Cool Dude');
+  t.equal(patchedShadow.serverVersion, 0, 'serverVersion should be 0');
+  t.equal(patchedShadow.clientVersion, 0, 'clientVersion should be 0');
 
   t.end();
 });


### PR DESCRIPTION
Motivation:
Add the handling of subscribers to the Node.js sync server by adding support for adding, patching and detaching subscribers. 

Modifications:
During the process of adding this support there we discovered that the data store implementation was lacking functionality and plain incorrect handling of document, shadowDocuments. We have added the functionality but there will be additional rounds to clean this up further. 

Result:
Should be possible to start the server using:
```shell
$ npm start
```
And start the manual websocket client:
```shell
$ node manual/ws.js
```

Not much to show or verify since CI will run all the test and linting.